### PR TITLE
Validação dupla (CPF e CNPJ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ use Yii;
 use yii\base\Model;
 use yiibr\brvalidator\CpfValidator;
 use yiibr\brvalidator\CnpjValidator;
+use yiibr\brvalidator\CpfCnpjValidator;
 use yiibr\brvalidator\CeiValidator;
 
 class PersonForm extends Model
@@ -65,6 +66,8 @@ class PersonForm extends Model
 			['cpf', CpfValidator::className()],
 			// cnpj validator
 			['cnpj', CnpjValidator::className()],
+			// both cnpj and cpf validator
+			['cpf_cnpj', CpfCnpjValidator::className()],
 			// cei validator
 			['cei', CeiValidator::className()]
 		];

--- a/src/CpfCnpjValidator.php
+++ b/src/CpfCnpjValidator.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * @link https://github.com/yiibr/yii2-br-validator
+ * @license https://github.com/yiibr/yii2-br-validator/blob/master/LICENSE
+ */
+namespace yiibr\brvalidator;
+
+use yii\helpers\Json;
+use Yii;
+
+/**
+ * CpfCnpjValidator checks if the attribute value is a valid CPF or CNPJ.
+ *
+ * @author Leandro Gehlen <leandrogehlen@gmail.com>
+ */
+class CpfCnpjValidator extends DocumentValidator
+{
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+        if ($this->message === null) {
+            $this->message = Yii::t('yii', "{attribute} is invalid.");
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function validateValue($value)
+    {
+        $valid = true;
+        $cpfCnpj = preg_replace('/[^0-9]/', '', $value);
+
+        for ($x=0; $x<10; $x++) {
+            if ( $cpfCnpj == str_repeat($x, 11) || $cpfCnpj == str_repeat($x, 14) ) {
+                $valid = false;
+            }
+        }
+        if ($valid) {
+            if (strlen($cpfCnpj) === 14) {
+                for ($t = 12; $t < 14; $t ++) {
+                    $d = 0;
+                    $c = 0;
+                    for ($m = $t - 7; $m >= 2; $m --, $c ++) {
+                        $d += $cpfCnpj [$c] * $m;
+                    }
+                    for ($m = 9; $m >= 2; $m --, $c ++) {
+                        $d += $cpfCnpj [$c] * $m;
+                    }
+                    $d = ((10 * $d) % 11) % 10;
+                    if ($cpfCnpj [$c] != $d) {
+                        $valid = false;
+                        break;
+                    }
+                }
+            } else if (strlen($cpfCnpj) === 11) {
+                for ($t = 9; $t < 11; $t ++) {
+                    $d = 0;
+                    for($c = 0; $c < $t; $c ++) {
+                        $d += $cpfCnpj [$c] * (($t + 1) - $c);
+                    }
+                    $d = ((10 * $d) % 11) % 10;
+                    if ($cpfCnpj[$c] != $d) {
+                        $valid = false;
+                        break;
+                    }
+                }
+            } else  {
+                $valid = false;
+            }
+        }
+        return ($valid) ? [] : [$this->message, []];
+    }
+
+    public function clientValidateAttribute($object, $attribute, $view)
+    {
+        $options = [
+            'message' => Yii::$app->getI18n()->format($this->message, [
+                'attribute' => $object->getAttributeLabel($attribute),
+            ], Yii::$app->language)
+        ];
+
+        if ($this->skipOnEmpty) {
+            $options['skipOnEmpty'] = 1;
+        }
+
+        ValidationAsset::register($view);
+        return 'yiibr.validation.cpfCnpj(value, messages, ' . Json::encode($options) . ');';
+    }
+}

--- a/src/assets/yiibr.validation.js
+++ b/src/assets/yiibr.validation.js
@@ -130,6 +130,93 @@ yiibr.validation = (function($) {
                 pub.addMessage(messages, options.message, value);
             }
         },
+        cpfCnpj: function(value, messages, options) {
+            if (options.skipOnEmpty && pub.isEmpty(value)) {
+                return;
+            }
+
+            String.prototype.repeat = function(num) {
+                return new Array(isNaN(num) ? 1 : ++num).join(this);
+            };
+
+            let valid = true;
+            const cpf_cnpj = value.replace(/\D/g, '');
+
+            if (pub.isAllCharEquals(cpf_cnpj)) {
+                valid = false;
+            } else if (cpf_cnpj.length == 14) {
+                size = cpf_cnpj.length - 2;
+                numbers = cpf_cnpj.substring(0, size);
+                digits = cpf_cnpj.substring(size);
+                sum = 0;
+                pos = size - 7;
+                for (i = size; i >= 1; i--) {
+                    sum += numbers.charAt(size - i) * pos--;
+                    if (pos < 2) {
+                        pos = 9;
+                    }
+                }
+                result = sum % 11 < 2 ? 0 : 11 - sum % 11;
+                if (result != digits.charAt(0)) {
+                    valid = false;
+                }
+
+                size = size + 1;
+                numbers = cpf_cnpj.substring(0, size);
+                sum = 0;
+                pos = size - 7;
+                for (i = size; i >= 1; i--) {
+                    sum += numbers.charAt(size - i) * pos--;
+                    if (pos < 2) {
+                        pos = 9;
+                    }
+                }
+                result = sum % 11 < 2 ? 0 : 11 - sum % 11;
+
+                if (result != digits.charAt(1)) {
+                    valid = false;
+                }
+            } else if(cpf_cnpj.length == 11){
+                for (let x = 0; x < 10; x++) {
+                    if (cpf_cnpj === x.toString().repeat(11)) {
+                        valid = false;
+                    }
+                }
+                if (valid) {
+                    const c = cpf_cnpj.substr(0, 9);
+                    const dv = cpf_cnpj.substr(9, 2);
+                    let d1 = 0;
+                    for (i = 0; i < 9; i++) {
+                        d1 += c.charAt(i) * (10 - i);
+                    }
+                    if (d1 == 0) {
+                        valid = false;
+                    } else {
+                        d1 = 11 - (d1 % 11);
+                        if (d1 > 9) d1 = 0;
+                        if (dv.charAt(0) != d1) {
+                            valid = false;
+                        } else {
+                            d1 *= 2;
+                            for (i = 0; i < 9; i++) {
+                                d1 += c.charAt(i) * (11 - i);
+                            }
+                            d1 = 11 - (d1 % 11);
+                            if (d1 > 9) d1 = 0;
+                            if (dv.charAt(1) != d1) {
+                                valid = false;
+                            }
+                        }
+                    }
+                }
+            } else {
+                valid = false;
+            }
+
+            if (!valid) {
+                pub.addMessage(messages, options.message, value);
+            }
+        }, 
         cei: function(value, messages, options) {
             if (options.skipOnEmpty && pub.isEmpty(value)) {
                 return;

--- a/tests/CpfCnpjValidatorTest.php
+++ b/tests/CpfCnpjValidatorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace yiibr\brvalidator\tests;
+
+use yiibr\brvalidator\CpfCnpjValidator;
+
+/**
+ * CpfCnpjValidatorTest
+ */
+class CpfCnpjValidatorTest extends TestCase
+{
+    public function testValidateValue()
+    {
+        $val = new CpfCnpjValidator();
+        $this->assertFalse($val->validate('78954228'));
+
+        $this->assertFalse($val->validate('11111111111'));
+        $this->assertFalse($val->validate('111.111.111-11'));
+        $this->assertFalse($val->validate('234.567.058-4_'));
+        $this->assertFalse($val->validate('222.451.811-08'));
+        $this->assertFalse($val->validate('22245181108'));
+
+        $this->assertTrue($val->validate('222.451.811-07'));
+        $this->assertTrue($val->validate('22245181107'));
+
+        $this->assertFalse($val->validate('22222222222222'));
+        $this->assertFalse($val->validate('22.222.222/2222-22'));        
+        $this->assertFalse($val->validate('32.458.657.0001-89'));
+        $this->assertFalse($val->validate('32458657000189'));
+
+        $this->assertTrue($val->validate('62346464000101'));
+        $this->assertTrue($val->validate('62.346.464/0001-01'));
+
+    }
+}


### PR DESCRIPTION
Como em alguns sistemas o campo de CPF e CNPJ ficam juntos, unificamos a validação para quando ocorrer estes casos, chamando o `CpfCnpjValidator`.